### PR TITLE
fix(derive): unqualified use of std::time::Duration in macro

### DIFF
--- a/crates/async-dropper-derive/src/lib.rs
+++ b/crates/async-dropper-derive/src/lib.rs
@@ -131,8 +131,8 @@ fn gen_preamble(di: &DeriveInput) -> proc_macro2::TokenStream {
             }
 
             /// Timeout for drop operation, meant to be overriden if needed
-            fn drop_timeout(&self) -> Duration {
-                Duration::from_secs(3)
+            fn drop_timeout(&self) -> std::time::Duration {
+                std::time::Duration::from_secs(3)
             }
 
             /// What to do what a drop fails


### PR DESCRIPTION
Up until now, the Duration used in AsyncDrop#drop_timeout was unqualified, which meant that downstream users of the lib would get errors since the struct wasn't imported.

This commit qualifies use of Duration in the generated code for the AsyncDrop derive macro to avoid errors/forcing downstream consumers to `use std::time::Duration`.

Resolves #8 