### PR TITLE
Add drop error handler

### DIFF
--- a/examples/derive_async_std.rs
+++ b/examples/derive_async_std.rs
@@ -34,7 +34,7 @@ impl AsyncDrop for AsyncThing {
         Duration::from_secs(5) // extended from default 3 seconds
     }
 
-    // NOTE: below was not implemented since we want the default of DropFailAction::Contineue
+    // NOTE: below was not implemented since we want the default of DropFailAction::Continue
     // fn drop_fail_action(&self) -> DropFailAction;
 }
 

--- a/examples/derive_tokio.rs
+++ b/examples/derive_tokio.rs
@@ -43,7 +43,7 @@ impl AsyncDrop for AsyncThing {
     //     self.value = String::default();
     // }
 
-    // NOTE: below was not implemented since we want the default of DropFailAction::Contineue
+    // NOTE: below was not implemented since we want the default of DropFailAction::Continue
     // fn drop_fail_action(&self) -> DropFailAction;
 }
 


### PR DESCRIPTION
Closes #7 
Added `AsyncDropError` handler. `Timeout` error is considered to be the same as task blocking wait timeout error. The behaviour can be controlled via `DropFailAction`. `UnexpectedError` is considered to be "always panic".