### PR TITLE
feat(ci): add conventional commits

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,14 @@
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  ensure-conventional-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Ensure conventional commits
+        uses: aevea/commitsar@916c7b483225a30d3a17f407fa25f5b25888ea69 # v0.20.2


### PR DESCRIPTION
This commit adds a check to CI that ensures that commits adhere to Conventional Commits (https://www.conventionalcommits.org)