### PR TITLE
feat(simple): remove static requirement by using async-scoped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 
 [workspace.dependencies]
 async-std = "1.12.0"
+async-scoped = "0.9.0"
 tokio = "1.33.0"
 async-trait = "0.1.74"
 proc-macro2 = "1.0.69"

--- a/crates/async-dropper-simple/Cargo.toml
+++ b/crates/async-dropper-simple/Cargo.toml
@@ -14,10 +14,11 @@ A simple struct-wrapper (i.e. AsyncDropper<T>) based implementation of AsyncDrop
 
 [features]
 default = []
-tokio = ["dep:tokio"]
-async-std = ["dep:async-std"]
+tokio = ["dep:tokio", "dep:async-scoped", "async-scoped/use-tokio"]
+async-std = ["dep:async-std", "dep:async-scoped", "async-scoped/use-async-std"]
 
 [dependencies]
+async-scoped = { workspace = true, optional = true }
 async-std = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
   "time",


### PR DESCRIPTION
This commit introduces `async-scoped` in order to remove the `'static` lifetime bounds on the async_drop task.