### PR TITLE
feat(simple): add no-default-bound feature

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -89,8 +89,10 @@ test-unit:
     @{{just}} ensure-binary cargo-nextest CARGO_NEXTEST
     @{{cargo}} nextest run -F tokio,derive     -E 'kind(lib)'
     @{{cargo}} nextest run -F tokio,simple     -E 'kind(lib)'
+    @{{cargo}} nextest run -F tokio,simple,no-default-bound -E 'kind(lib)'
     @{{cargo}} nextest run -F async-std,derive -E 'kind(lib)'
     @{{cargo}} nextest run -F async-std,simple -E 'kind(lib)'
+    @{{cargo}} nextest run -F async-std,simple,no-default-bound -E 'kind(lib)'
 
 # Run unit tests continuously
 test-unit-watch:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ You can run the example and see the output:
 cargo run --example simple-tokio --features=tokio
 ```
 
+### Don't like the `Default` requirement?
+
+It [was suggested](https://github.com/t3hmrman/async-dropper/issues/12#issuecomment-1913642636) that for certain large structs, it may not be convenient to implement `Default` in order to use the simple `AsyncDropper`.
+
+As of version `0.2.6`, `async-dropper-simple` has a feature flag called `no-default-bound` which allows you to skip the `Default` bound on your `T` (in `AsyncDropper<T>`), by using an inner `Option<T>` (thanks @beckend!).
+
 ### `async_dropper::derive`
 
 The derive macro is a novel (and possibly foolhardy) attempt to implement `AsyncDrop` without actually wrapping the existing struct.

--- a/crates/async-dropper-simple/Cargo.toml
+++ b/crates/async-dropper-simple/Cargo.toml
@@ -16,6 +16,7 @@ A simple struct-wrapper (i.e. AsyncDropper<T>) based implementation of AsyncDrop
 default = []
 tokio = ["dep:tokio", "dep:async-scoped", "async-scoped/use-tokio"]
 async-std = ["dep:async-std", "dep:async-scoped", "async-scoped/use-async-std"]
+no-default-bound = []
 
 [dependencies]
 async-scoped = { workspace = true, optional = true }
@@ -32,6 +33,7 @@ async-trait.workspace = true
 rustc_version = "0.4.0"
 
 [dev-dependencies]
+async-std = { workspace = true, features = [ "attributes", "tokio1" ] }
 tokio = { workspace = true, features = [
   "time",
   "macros",

--- a/crates/async-dropper-simple/README.md
+++ b/crates/async-dropper-simple/README.md
@@ -6,3 +6,11 @@
 - `async_dropper::derive` provides a trait called `AsyncDrop` and corresponding [derive macro][rust-derive-macro], which try to use `Default` and `PartialEq` to determine when to async drop.
 
 The code in this crate powers `async_dropper::simple`. See the `async_dropper` crate for more details.
+
+## Feature flags
+
+| Flag               | Description                                                                           |
+|--------------------|---------------------------------------------------------------------------------------|
+| `tokio`            | Use the [`tokio`][tokio] async runtime                                                |
+| `async-std`        | use the [`async-std`][async-std] async runtime                                        |
+| `no-default-bound` | Avoid the `Default` bound on your `T` by wrapping the interior data in an `Option<T>` |

--- a/crates/async-dropper-simple/src/default.rs
+++ b/crates/async-dropper-simple/src/default.rs
@@ -1,0 +1,309 @@
+//! Implementation of simple AsyncDropper that does not require `Default`
+//!
+//! This implementation might be preferrable for people who cannot reasonably
+//! implement `Default` for their struct, but have easily accessible `Eq`,`PartialEq`,
+//! `Hash`, and/or `Clone` instances.
+#![cfg(not(feature = "no-default-bound"))]
+
+use std::ops::{Deref, DerefMut};
+use std::time::Duration;
+
+use crate::AsyncDrop;
+
+/// Wrapper struct that enables `async_drop()` behavior.
+///
+/// This version requires a `Default` implementation.
+#[derive(Default)]
+#[allow(dead_code)]
+pub struct AsyncDropper<T: AsyncDrop + Default + Send + 'static> {
+    dropped: bool,
+    timeout: Option<Duration>,
+    inner: T,
+}
+
+impl<T: AsyncDrop + Default + Send + 'static> AsyncDropper<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            dropped: false,
+            timeout: None,
+            inner,
+        }
+    }
+
+    pub fn with_timeout(timeout: Duration, inner: T) -> Self {
+        Self {
+            dropped: false,
+            timeout: Some(timeout),
+            inner,
+        }
+    }
+
+    /// Get a reference to the inner data
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable refrence to inner data
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T> Deref for AsyncDropper<T>
+where
+    T: AsyncDrop + Send + Default,
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.inner()
+    }
+}
+
+impl<T> DerefMut for AsyncDropper<T>
+where
+    T: AsyncDrop + Send + Default,
+{
+    fn deref_mut(&mut self) -> &mut T {
+        self.inner_mut()
+    }
+}
+
+#[cfg(all(not(feature = "tokio"), not(feature = "async-std")))]
+impl<T: AsyncDrop + Default + Send + 'static> Drop for AsyncDropper<T> {
+    fn drop(&mut self) {
+        compile_error!(
+            "either 'async-std' or 'tokio' features must be enabled for the async-dropper crate"
+        )
+    }
+}
+
+#[cfg(all(feature = "async-std", feature = "tokio"))]
+impl<T: AsyncDrop + Default + Send + 'static> Drop for AsyncDropper<T> {
+    fn drop(&mut self) {
+        compile_error!(
+            "'async-std' and 'tokio' features cannot both be specified for the async-dropper crate"
+        )
+    }
+}
+
+#[cfg(all(feature = "tokio", not(feature = "async-std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+impl<T: AsyncDrop + Default + Send + 'static> Drop for AsyncDropper<T> {
+    fn drop(&mut self) {
+        if !self.dropped {
+            use async_scoped::TokioScope;
+
+            // Set the original instance to be dropped
+            self.dropped = true;
+
+            // Save the timeout on the original instance
+            let timeout = self.timeout;
+
+            // Swap out the current instance with default
+            // (i.e. `this` is now original instance, and `self` is a default instance)
+            let mut this = std::mem::take(self);
+
+            // Set the default instance to note that it's dropped
+            self.dropped = true;
+
+            // Create task
+            match timeout {
+                // If a timeout was specified, use it when performing async_drop
+                Some(d) => {
+                    TokioScope::scope_and_block(|s| {
+                        s.spawn(tokio::time::timeout(d, async move {
+                            this.inner.async_drop().await;
+                        }))
+                    });
+                }
+                // If no timeout was specified, perform async_drop() indefinitely
+                None => {
+                    TokioScope::scope_and_block(|s| {
+                        s.spawn(async move {
+                            this.inner.async_drop().await;
+                        })
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "async-std", not(feature = "tokio")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
+impl<T: AsyncDrop + Default + Send + 'static> Drop for AsyncDropper<T> {
+    fn drop(&mut self) {
+        if !self.dropped {
+            use async_scoped::AsyncStdScope;
+
+            // Set the original instance to be dropped
+            self.dropped = true;
+
+            // Save the timeout on the original instance
+            let timeout = self.timeout;
+
+            // Swap out the current instance with default
+            // (i.e. `this` is now original instance, and `self` is a default instance)
+            let mut this = std::mem::take(self);
+
+            // Set the default instance to note that it's dropped
+            self.dropped = true;
+
+            match timeout {
+                // If a timeout was specified, use it when performing async_drop
+                Some(d) => {
+                    AsyncStdScope::scope_and_block(|s| {
+                        s.spawn(async_std::future::timeout(d, async move {
+                            this.inner.async_drop().await;
+                        }))
+                    });
+                }
+                // If no timeout was specified, perform async_drop() indefinitely
+                None => {
+                    AsyncStdScope::scope_and_block(|s| {
+                        s.spawn(async move {
+                            this.inner.async_drop().await;
+                        })
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+
+    use crate::{AsyncDrop, AsyncDropper};
+
+    /// Testing struct
+    struct Test {
+        // This counter is used as an indicator of how far async_drop() gets
+        // - 0 means async_drop() never ran
+        // - 1 means async_drop() started but did not complete
+        // - 2 means async_drop() completed
+        counter: Arc<AtomicU32>,
+    }
+
+    impl Default for Test {
+        fn default() -> Self {
+            Self {
+                counter: Arc::new(AtomicU32::new(0)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AsyncDrop for Test {
+        async fn async_drop(&mut self) {
+            self.counter.store(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            self.counter.store(2, Ordering::SeqCst);
+        }
+    }
+
+    /// Ensure that non-`Default`-bounded dropper works with tokio
+    #[cfg(feature = "tokio")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tokio_works() {
+        let start = std::time::Instant::now();
+        let counter = Arc::new(AtomicU32::new(0));
+
+        // Create and perform drop
+        let wrapped_t = AsyncDropper::new(Test {
+            counter: counter.clone(),
+        });
+        drop(wrapped_t);
+
+        assert!(
+            start.elapsed() > Duration::from_millis(500),
+            "two seconds have passed since drop"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            2,
+            "async_drop() ran to completion"
+        );
+    }
+
+    // TODO: this test is broken *because* of the timeout bug
+    // see: https://github.com/t3hmrman/async-dropper/pull/17
+    /// Ensure that non-`Default`-bounded dropper works with tokio with a timeout
+    #[cfg(feature = "tokio")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tokio_works_with_timeout() {
+        let start = std::time::Instant::now();
+        let counter = Arc::new(AtomicU32::new(0));
+        let wrapped_t = AsyncDropper::with_timeout(
+            Duration::from_millis(500),
+            Test {
+                counter: counter.clone(),
+            },
+        );
+        drop(wrapped_t);
+        assert!(
+            start.elapsed() > Duration::from_millis(500),
+            "two seconds have passed since drop"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "async_drop() did not run to completion (should have timed out)"
+        );
+    }
+
+    /// Ensure that non-`Default`-bounded dropper works with async-std
+    #[cfg(feature = "async-std")]
+    #[async_std::test]
+    async fn async_std_works() {
+        let start = std::time::Instant::now();
+        let counter = Arc::new(AtomicU32::new(0));
+
+        let wrapped_t = AsyncDropper::new(Test {
+            counter: counter.clone(),
+        });
+        drop(wrapped_t);
+
+        assert!(
+            start.elapsed() > Duration::from_millis(500),
+            "two seconds have passed since drop"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            2,
+            "async_drop() ran to completion"
+        );
+    }
+
+    // TODO: this test is broken *because* of the timeout bug
+    // see: https://github.com/t3hmrman/async-dropper/pull/17
+    /// Ensure that non-`Default`-bounded dropper works with async-std with a timeout
+    #[cfg(feature = "async-std")]
+    #[async_std::test]
+    async fn async_std_works_with_timeout() {
+        let start = std::time::Instant::now();
+        let counter = Arc::new(AtomicU32::new(0));
+        let wrapped_t = AsyncDropper::with_timeout(
+            Duration::from_millis(500),
+            Test {
+                counter: counter.clone(),
+            },
+        );
+        drop(wrapped_t);
+        assert!(
+            start.elapsed() > Duration::from_millis(500),
+            "two seconds have passed since drop"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "async_drop() did not run to completion (should have timed out)"
+        );
+    }
+}

--- a/crates/async-dropper-simple/src/lib.rs
+++ b/crates/async-dropper-simple/src/lib.rs
@@ -2,169 +2,17 @@
 //! The code in this file was shamelessly stolen from
 //! https://stackoverflow.com/questions/71541765/rust-async-drop
 
-use std::ops::{Deref, DerefMut};
-use std::time::Duration;
-
 #[async_trait::async_trait]
 pub trait AsyncDrop {
     async fn async_drop(&mut self);
 }
 
-#[derive(Default)]
-#[allow(dead_code)]
-pub struct AsyncDropper<T: AsyncDrop + Default + Send> {
-    dropped: bool,
-    timeout: Option<Duration>,
-    inner: T,
-}
+#[cfg(feature = "no-default-bound")]
+mod no_default_bound;
+#[cfg(feature = "no-default-bound")]
+pub use no_default_bound::AsyncDropper;
 
-impl<T: AsyncDrop + Default + Send> AsyncDropper<T> {
-    pub fn new(inner: T) -> Self {
-        Self {
-            dropped: false,
-            timeout: None,
-            inner,
-        }
-    }
-
-    pub fn with_timeout(timeout: Duration, inner: T) -> Self {
-        Self {
-            dropped: false,
-            timeout: Some(timeout),
-            inner,
-        }
-    }
-
-    /// Get a reference to the inner data
-    pub fn inner(&self) -> &T {
-        &self.inner
-    }
-
-    /// Get a mutable refrence to inner data
-    pub fn inner_mut(&mut self) -> &mut T {
-        &mut self.inner
-    }
-}
-
-impl<T> Deref for AsyncDropper<T>
-where
-    T: AsyncDrop + Send + Default,
-{
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        self.inner()
-    }
-}
-
-impl<T> DerefMut for AsyncDropper<T>
-where
-    T: AsyncDrop + Send + Default,
-{
-    fn deref_mut(&mut self) -> &mut T {
-        self.inner_mut()
-    }
-}
-
-#[cfg(all(not(feature = "tokio"), not(feature = "async-std")))]
-impl<T: AsyncDrop + Default + Send> Drop for AsyncDropper<T> {
-    fn drop(&mut self) {
-        compile_error!(
-            "either 'async-std' or 'tokio' features must be enabled for the async-dropper crate"
-        )
-    }
-}
-
-#[cfg(all(feature = "async-std", feature = "tokio"))]
-impl<T: AsyncDrop + Default + Send> Drop for AsyncDropper<T> {
-    fn drop(&mut self) {
-        compile_error!(
-            "'async-std' and 'tokio' features cannot both be specified for the async-dropper crate"
-        )
-    }
-}
-
-#[cfg(all(feature = "tokio", not(feature = "async-std")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
-impl<T: AsyncDrop + Default + Send> Drop for AsyncDropper<T> {
-    fn drop(&mut self) {
-        if !self.dropped {
-            use async_scoped::TokioScope;
-
-            // Set the original instance to be dropped
-            self.dropped = true;
-
-            // Save the timeout on the original instance
-            let timeout = self.timeout;
-
-            // Swap out the current instance with default
-            // (i.e. `this` is now original instance, and `self` is a default instance)
-            let mut this = std::mem::take(self);
-
-            // Set the default instance to note that it's dropped
-            self.dropped = true;
-
-            // Create task
-            match timeout {
-                // If a timeout was specified, use it when performing async_drop
-                Some(d) => {
-                    TokioScope::scope_and_block(|s| {
-                        s.spawn(tokio::time::timeout(d, async move {
-                            this.inner.async_drop().await;
-                        }))
-                    });
-                }
-                // If no timeout was specified, perform async_drop() indefinitely
-                None => {
-                    TokioScope::scope_and_block(|s| {
-                        s.spawn(async move {
-                            this.inner.async_drop().await;
-                        })
-                    });
-                }
-            }
-        }
-    }
-}
-
-#[cfg(all(feature = "async-std", not(feature = "tokio")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
-impl<T: AsyncDrop + Default + Send> Drop for AsyncDropper<T> {
-    fn drop(&mut self) {
-        if !self.dropped {
-            use async_scoped::AsyncStdScope;
-
-            // Set the original instance to be dropped
-            self.dropped = true;
-
-            // Save the timeout on the original instance
-            let timeout = self.timeout;
-
-            // Swap out the current instance with default
-            // (i.e. `this` is now original instance, and `self` is a default instance)
-            let mut this = std::mem::take(self);
-
-            // Set the default instance to note that it's dropped
-            self.dropped = true;
-
-            match timeout {
-                // If a timeout was specified, use it when performing async_drop
-                Some(d) => {
-                    AsyncStdScope::scope_and_block(|s| {
-                        s.spawn(async_std::future::timeout(d, async move {
-                            this.inner.async_drop().await;
-                        }))
-                    });
-                }
-                // If no timeout was specified, perform async_drop() indefinitely
-                None => {
-                    AsyncStdScope::scope_and_block(|s| {
-                        s.spawn(async move {
-                            this.inner.async_drop().await;
-                        })
-                    });
-                }
-            }
-        }
-    }
-}
+#[cfg(not(feature = "no-default-bound"))]
+mod default;
+#[cfg(not(feature = "no-default-bound"))]
+pub use default::AsyncDropper;

--- a/crates/async-dropper-simple/src/no_default_bound.rs
+++ b/crates/async-dropper-simple/src/no_default_bound.rs
@@ -1,0 +1,345 @@
+//! Implementation of simple AsyncDropper that does not require `Default`
+//!
+//! This implementation might be preferrable for people who cannot reasonably
+//! implement `Default` for their struct, but have easily accessible `Eq`,`PartialEq`,
+//! `Hash`, and/or `Clone` instances.
+#![cfg(feature = "no-default-bound")]
+
+use std::ops::{Deref, DerefMut};
+use std::time::Duration;
+
+use crate::AsyncDrop;
+
+/// Wrapper struct that enables `async_drop()` behavior.
+///
+/// This version does not require `Default`, via the user of an inner `Option<T>`
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[allow(dead_code)]
+pub struct AsyncDropper<T: AsyncDrop + Send + 'static> {
+    dropped: bool,
+    timeout: Option<Duration>,
+    inner: Option<T>,
+}
+
+impl<T: AsyncDrop + Send + 'static> AsyncDropper<T> {
+    /// Create an `AsyncDropper<T>` without a timeout
+    pub fn new(inner: T) -> Self {
+        Self {
+            dropped: false,
+            timeout: None,
+            inner: Some(inner),
+        }
+    }
+
+    /// Create an `AsyncDropper<T>` with a given timeout
+    pub fn with_timeout(timeout: Duration, inner: T) -> Self {
+        Self {
+            dropped: false,
+            timeout: Some(timeout),
+            inner: Some(inner),
+        }
+    }
+
+    /// Get a reference to the inner data
+    pub fn inner(&self) -> &T {
+        self.inner
+            .as_ref()
+            .expect("failed to retreive inner content")
+    }
+
+    /// Get a mutable refrence to inner data
+    pub fn inner_mut(&mut self) -> &mut T {
+        self.inner
+            .as_mut()
+            .expect("failed to retrieve inner content")
+    }
+}
+
+/// Choosing to *not* create the default T instance
+/// means that you must rely on `new()` or `with_timeout()` to create
+/// new `AsyncDropper` instances that have an `inner` specified
+impl<T: AsyncDrop + Send> Default for AsyncDropper<T> {
+    fn default() -> Self {
+        Self {
+            dropped: false,
+            timeout: None,
+            inner: None,
+        }
+    }
+}
+
+impl<T> Deref for AsyncDropper<T>
+where
+    T: AsyncDrop + Send + Default,
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.inner()
+    }
+}
+
+impl<T> DerefMut for AsyncDropper<T>
+where
+    T: AsyncDrop + Send + Default,
+{
+    fn deref_mut(&mut self) -> &mut T {
+        self.inner_mut()
+    }
+}
+
+#[cfg(all(not(feature = "tokio"), not(feature = "async-std")))]
+impl<T: AsyncDrop + Send + 'static> Drop for AsyncDropper<T> {
+    fn drop(&mut self) {
+        compile_error!(
+            "either 'async-std' or 'tokio' features must be enabled for the async-dropper crate"
+        )
+    }
+}
+
+#[cfg(all(feature = "async-std", feature = "tokio"))]
+impl<T: AsyncDrop + Send + 'static> Drop for AsyncDropper<T> {
+    fn drop(&mut self) {
+        compile_error!(
+            "'async-std' and 'tokio' features cannot both be specified for the async-dropper crate"
+        )
+    }
+}
+
+#[cfg(all(feature = "tokio", not(feature = "async-std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+impl<T: AsyncDrop + Send + 'static> Drop for AsyncDropper<T> {
+    fn drop(&mut self) {
+        if !self.dropped {
+            use async_scoped::TokioScope;
+
+            // Set the original instance to be dropped
+            self.dropped = true;
+
+            // Save the timeout on the original instance
+            let timeout = self.timeout;
+
+            // Swap out the current instance with default
+            // (i.e. `this` is now original instance, and `self` is a default instance)
+            let mut this = std::mem::take(self);
+
+            // Set the default instance to note that it's dropped
+            self.dropped = true;
+
+            // Create task
+            match timeout {
+                // If a timeout was specified, use it when performing async_drop
+                Some(d) => {
+                    TokioScope::scope_and_block(|s| {
+                        s.spawn(tokio::time::timeout(d, async move {
+                            this.inner
+                                .take()
+                                .expect(
+                                    "unexpectedly failed to take ownership AsyncDropper inner data",
+                                )
+                                .async_drop()
+                                .await;
+                        }))
+                    });
+                }
+                // If no timeout was specified, perform async_drop() indefinitely
+                None => {
+                    TokioScope::scope_and_block(|s| {
+                        s.spawn(async move {
+                            this.inner
+                                .take()
+                                .expect(
+                                    "unexpectedly failed to take ownership AsyncDropper inner data",
+                                )
+                                .async_drop()
+                                .await;
+                        })
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "async-std", not(feature = "tokio")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
+impl<T: AsyncDrop + Send + 'static> Drop for AsyncDropper<T> {
+    fn drop(&mut self) {
+        if !self.dropped {
+            use async_scoped::AsyncStdScope;
+
+            // Set the original instance to be dropped
+            self.dropped = true;
+
+            // Save the timeout on the original instance
+            let timeout = self.timeout;
+
+            // Swap out the current instance with default
+            // (i.e. `this` is now original instance, and `self` is a default instance)
+            let mut this = std::mem::take(self);
+
+            // Set the default instance to note that it's dropped
+            self.dropped = true;
+
+            match timeout {
+                // If a timeout was specified, use it when performing async_drop
+                Some(d) => {
+                    AsyncStdScope::scope_and_block(|s| {
+                        s.spawn(async_std::future::timeout(d, async move {
+                            this.inner
+                                .take()
+                                .expect(
+                                    "unexpectedly failed to take ownership AsyncDropper inner data",
+                                )
+                                .async_drop()
+                                .await;
+                        }))
+                    });
+                }
+                // If no timeout was specified, perform async_drop() indefinitely
+                None => {
+                    AsyncStdScope::scope_and_block(|s| {
+                        s.spawn(async move {
+                            this.inner
+                                .take()
+                                .expect(
+                                    "unexpectedly failed to take ownership AsyncDropper inner data",
+                                )
+                                .async_drop()
+                                .await;
+                        })
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+
+    use crate::{AsyncDrop, AsyncDropper};
+
+    /// Testing struct which contains an arc to an atomic counter
+    /// so that we can tell how far drop gets, if necessary
+    struct Test {
+        // This counter is used as an indicator of how far async_drop() gets
+        // - 0 means async_drop() never ran
+        // - 1 means async_drop() started but did not complete
+        // - 2 means async_drop() completed
+        counter: Arc<AtomicU32>,
+    }
+
+    #[async_trait]
+    impl AsyncDrop for Test {
+        async fn async_drop(&mut self) {
+            self.counter.store(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            self.counter.store(2, Ordering::SeqCst);
+        }
+    }
+
+    /// Ensure that non-`Default`-bounded dropper works with tokio
+    #[cfg(feature = "tokio")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tokio_works() {
+        let start = std::time::Instant::now();
+        let counter = Arc::new(AtomicU32::new(0));
+
+        // Create and perform drop
+        let wrapped_t = AsyncDropper::new(Test {
+            counter: counter.clone(),
+        });
+        drop(wrapped_t);
+
+        assert!(
+            start.elapsed() > Duration::from_millis(500),
+            "two seconds have passed since drop"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            2,
+            "async_drop() ran to completion"
+        );
+    }
+
+    // TODO: this test is broken *because* of the timeout bug
+    // see: https://github.com/t3hmrman/async-dropper/pull/17
+    /// Ensure that non-`Default`-bounded dropper works with tokio with a timeout
+    #[cfg(feature = "tokio")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tokio_works_with_timeout() {
+        let start = std::time::Instant::now();
+        let counter = Arc::new(AtomicU32::new(0));
+        let wrapped_t = AsyncDropper::with_timeout(
+            Duration::from_millis(500),
+            Test {
+                counter: counter.clone(),
+            },
+        );
+        drop(wrapped_t);
+        assert!(
+            start.elapsed() > Duration::from_millis(500),
+            "two seconds have passed since drop"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "async_drop() did not run to completion (should have timed out)"
+        );
+    }
+
+    /// Ensure that non-`Default`-bounded dropper works with async-std
+    #[cfg(feature = "async-std")]
+    #[async_std::test]
+    async fn async_std_works() {
+        let start = std::time::Instant::now();
+        let counter = Arc::new(AtomicU32::new(0));
+
+        let wrapped_t = AsyncDropper::new(Test {
+            counter: counter.clone(),
+        });
+        drop(wrapped_t);
+
+        assert!(
+            start.elapsed() > Duration::from_millis(500),
+            "two seconds have passed since drop"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            2,
+            "async_drop() ran to completion"
+        );
+    }
+
+    // TODO: this test is broken *because* of the timeout bug
+    // see: https://github.com/t3hmrman/async-dropper/pull/17
+    /// Ensure that non-`Default`-bounded dropper works with async-std with a timeout
+    #[cfg(feature = "async-std")]
+    #[async_std::test]
+    async fn async_std_works_with_timeout() {
+        let start = std::time::Instant::now();
+        let counter = Arc::new(AtomicU32::new(0));
+        let wrapped_t = AsyncDropper::with_timeout(
+            Duration::from_millis(500),
+            Test {
+                counter: counter.clone(),
+            },
+        );
+        drop(wrapped_t);
+        assert!(
+            start.elapsed() > Duration::from_millis(500),
+            "two seconds have passed since drop"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "async_drop() did not run to completion (should have timed out)"
+        );
+    }
+}


### PR DESCRIPTION
For those who cannot easily implement `Default` (ex. a large struct), a version of the simple dropper that relies on an inner `Option<T>` can be more convenient to write.

This commit adds a feature flag `no-default-bound` that removes the `Default` bound requirement.