### PR TITLE
refactor(derive): drop tokio dependency

### DIFF
--- a/crates/async-dropper-derive/Cargo.toml
+++ b/crates/async-dropper-derive/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 
 [features]
 default = []
-tokio = ["dep:tokio"]
+tokio = []
 async-std = ["dep:async-std"]
 
 [dependencies]
@@ -26,7 +26,6 @@ async-trait.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-tokio = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 all-features = false


### PR DESCRIPTION
The references to 'tokio' in `async-dropper-derive` are in quoted code, that crate is a proc macro that doesn't need tokio to run (ie. to manipulate token streams).

Leaving it in as a dependency just means tokio would show up twice in the dep graph, built once for `async-dropper-derive` (as a proc macro dependency and unused), and once as a regular dependency.

Having it as a dependency of `async-dropper-derive` also doesn't force users of the `derive` feature to have a dependency on tokio: they can still have compile errors due to the `tokio` symbol not being found if they don't _also_ depend on tokio in their crate, just like how <https://docs.rs/tracing-test/latest/tracing_test/> cannot force your crate to depend on `tracing` (even though its macro expansion needs it).