### PR TITLE
no_default_bound: remove Default bound in Deref/DerefMut

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -102,10 +102,10 @@ test-unit-watch:
 
 test-int:
     @{{just}} ensure-binary cargo-nextest CARGO_NEXTEST
-    @{{cargo}} nextest run -F tokio,derive     -E 'kind(test)'
-    @{{cargo}} nextest run -F tokio,simple     -E 'kind(test)'
-    @{{cargo}} nextest run -F async-std,derive -E 'kind(test)'
-    @{{cargo}} nextest run -F async-std,simple -E 'kind(test)'
+    @{{cargo}} nextest run --no-tests=pass -F tokio,derive     -E 'kind(test)'
+    @{{cargo}} nextest run --no-tests=pass -F tokio,simple     -E 'kind(test)'
+    @{{cargo}} nextest run --no-tests=pass -F async-std,derive -E 'kind(test)'
+    @{{cargo}} nextest run --no-tests=pass -F async-std,simple -E 'kind(test)'
 
 test-examples:
     @{{cargo}} run --example simple-tokio --features=tokio,simple

--- a/crates/async-dropper-simple/src/no_default_bound.rs
+++ b/crates/async-dropper-simple/src/no_default_bound.rs
@@ -70,7 +70,7 @@ impl<T: AsyncDrop + Send> Default for AsyncDropper<T> {
 
 impl<T> Deref for AsyncDropper<T>
 where
-    T: AsyncDrop + Send + Default,
+    T: AsyncDrop + Send,
 {
     type Target = T;
 
@@ -81,7 +81,7 @@ where
 
 impl<T> DerefMut for AsyncDropper<T>
 where
-    T: AsyncDrop + Send + Default,
+    T: AsyncDrop + Send,
 {
     fn deref_mut(&mut self) -> &mut T {
         self.inner_mut()


### PR DESCRIPTION
I suspect this bound was retained in error, probably a copy-paste from the default version. :)